### PR TITLE
docs: release v1.90: change raw link to hyperlink with descriptive text

### DIFF
--- a/docs/csharp/debugging.md
+++ b/docs/csharp/debugging.md
@@ -141,6 +141,12 @@ With the help of expression evaluation, the debugger also supports conditional b
 
 ![Conditional Breakpoints](images/debugging/conditional-breakpoint.gif)
 
+### Breakpoint - Function Breakpoint
+
+The debugger also supports functional breakpoints. You can set your breakpoint to break on the specific function by clicking on the `+` in the Breakpoints section of the Debug pane.
+
+![Function Breakpoints](images/debugging/function-breakpoint.gif)
+
 ### Breakpoint - Logpoints
 
 Logpoints (also known as Tracepoints in Visual Studio) allow you to send output to Debug Console without editing code. They're different from breakpoints because they don't stop the execution flow of your application.

--- a/docs/csharp/images/debugging/function-breakpoint.gif
+++ b/docs/csharp/images/debugging/function-breakpoint.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1497e3c357bf8aef3de8a5bdbf5b4e0f5a204ccd19a494a40cb881a4b83372f3
+size 1048102

--- a/release-notes/v1_90.md
+++ b/release-notes/v1_90.md
@@ -295,7 +295,7 @@ for await (const part of response.text) {
 }
 ```
 
-This is the gist of the language model API. Head over to https://github.com/microsoft/vscode-extension-samples/tree/main/chat-sample for a more complete example. Stay tuned for more samples, documentation, and further extensions of the API.
+This is the gist of the language model API. Refer to the [extension sample](https://github.com/microsoft/vscode-extension-samples/tree/main/chat-sample) for a more complete example. Stay tuned for more samples, documentation, and further extensions of the API.
 
 The Java extension for VS Code is already using the Language Model API to provide Copilot-based rewrite capabilities for your Java code. Learn more about these updates in the [Java in Visual Studio Code May 2024](https://devblogs.microsoft.com/java/java-on-visual-studio-code-update-may-2024/) blog post.
 

--- a/release-notes/v1_90.md
+++ b/release-notes/v1_90.md
@@ -301,7 +301,7 @@ The Java extension for VS Code is already using the Language Model API to provid
 
 ##### `@vscode/prompt-tsx` library
 
-To aid with developing GitHub Copilot extensions for VS Code, we've developed and published a TSX-based library for declaring complex prompts and converting them to chat messages, subject to your LLM's context window limits. In developing this, we took inspiration from Anysphere's [`priompt`](https://github.com/anysphere/priompt) library. If you're an extension author who is planning to use the chat and language model APIs, consider trying out the latest alpha release of this library: https://www.npmjs.com/package/@vscode/prompt-tsx
+To aid with developing GitHub Copilot extensions for VS Code, we've developed and published a TSX-based library for declaring complex prompts and converting them to chat messages, subject to your LLM's context window limits. In developing this, we took inspiration from Anysphere's [`priompt`](https://github.com/anysphere/priompt) library. If you're an extension author who is planning to use the chat and language model APIs, consider trying out the latest alpha release of this library: [@vscode/prompt-tsx](https://www.npmjs.com/package/@vscode/prompt-tsx).
 
 ### Extending GitHub Copilot through GitHub Apps
 


### PR DESCRIPTION
Was a bit surprised by the raw un-clickable link.
![image](https://github.com/zaidhaan/vscode-docs/assets/5954994/8311d60b-972d-4c3e-b1fc-325ea9e6408c)

I reworded it a little and added a hyperlink.